### PR TITLE
feat: add user management pagination

### DIFF
--- a/src/pages/auth/components/UserManagementTable.tsx
+++ b/src/pages/auth/components/UserManagementTable.tsx
@@ -8,7 +8,6 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -16,8 +15,8 @@ import { AlertTriangle } from 'lucide-react';
 import { UserActionMenu } from './UserActionMenu';
 import { ProfessionalActions } from './ProfessionalActions';
 import { UserStatusBadge } from './UserStatusBadge';
-import { UserTypeBadge } from './UserTypeBadge';
 import { UserRoleManagement } from '@/components/admin/users/UserRoleManagement';
+import { UserPagination } from '@/components/users/UserPagination';
 import type { AdminUser } from '../types/admin-user';
 
 interface UserManagementTableProps {
@@ -44,6 +43,10 @@ export const UserManagementTable: React.FC<UserManagementTableProps> = ({
   onUserSelection,
   onSelectAll,
   filteredUsers,
+  currentPage,
+  totalPages,
+  usersPerPage,
+  onPageChange,
 }) => {
   const getUserType = (user: AdminUser) => {
     return user.user_metadata?.user_type || 'client';
@@ -175,6 +178,13 @@ export const UserManagementTable: React.FC<UserManagementTableProps> = ({
           </TableBody>
         </Table>
       </div>
+      <UserPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalUsers={filteredUsers.length}
+        usersPerPage={usersPerPage}
+        onPageChange={onPageChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add pagination controls to user management table
- clean up unused imports

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e94ac583483219a9f42b98a738d1e