### PR TITLE
Use edge function for role updates

### DIFF
--- a/src/components/admin/users/UserRoleManagement.tsx
+++ b/src/components/admin/users/UserRoleManagement.tsx
@@ -78,17 +78,18 @@ export const UserRoleManagement: React.FC<UserRoleManagementProps> = ({
 
     setIsUpdating(true);
     try {
-      const result = await assignRoleToUser(user.id, selectedRole);
-      
-      if (result.success) {
+      const { success, error } = await assignRoleToUser(user.id, selectedRole);
+
+      if (success) {
         toast.success(`User role updated to ${selectedRole}`);
-        onRoleUpdate?.();
+        await onRoleUpdate?.();
         setIsOpen(false);
       } else {
-        toast.error('Failed to update user role');
+        toast.error(error?.message || 'Failed to update user role');
       }
-    } catch (error) {
-      toast.error('An error occurred while updating the role');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'An error occurred while updating the role';
+      toast.error(message);
     } finally {
       setIsUpdating(false);
     }


### PR DESCRIPTION
## Summary
- call Supabase `update-user-role` edge function inside `usePermissionsSystem.assignRoleToUser`
- surface errors and refresh user data in `UserRoleManagement`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 535 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e949955248321b3d2497021a4689a