### PR TITLE
fix: ensure session retrieval before deleting user

### DIFF
--- a/src/pages/auth/hooks/useUserActions.ts
+++ b/src/pages/auth/hooks/useUserActions.ts
@@ -204,10 +204,10 @@ export const useUserActions = () => {
       setIsLoading(true);
       console.log('Attempting to completely delete user from auth:', userId);
       
-      const { data: { session }, error: sessionError } = await supabase.auth.refreshSession();
-      
+      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+
       if (sessionError || !session) {
-        console.error('Session refresh failed:', sessionError);
+        console.error('Failed to retrieve session:', sessionError);
         const error = new Error('Authentication required - please log in again');
         await logAdminError('delete_user', error, userId);
         throw error;


### PR DESCRIPTION
## Summary
- avoid session refresh and use current session when deleting users to prevent auth errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 534 problems (496 errors, 38 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689f58046ad08321bdbe4d69590bcf90