### PR TITLE
Delete user profile on user removal

### DIFF
--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -104,6 +104,24 @@ serve(async (req) => {
         });
       }
 
+      const { error: profileError } = await supabase
+        .from('user_profiles')
+        .delete()
+        .eq('user_id', user_id);
+
+      if (profileError) {
+        console.error(`Failed to delete user profile: ${profileError.message}`);
+        return new Response(JSON.stringify({
+          success: false,
+          error: `Failed to delete user profile: ${profileError.message}`
+        }), {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" }
+        });
+      }
+
+      console.log(`Successfully deleted user profile for ${user_id}`);
+
       console.log(`Successfully deleted user ${user_id} from authentication system`);
       
       return new Response(JSON.stringify({


### PR DESCRIPTION
## Summary
- Delete `user_profiles` record after user is removed from auth
- Handle and report errors from profile deletion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 534 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689f4d548d74832184948ba3a2e2a4be