### PR TITLE
refactor: clean up role update error handling

### DIFF
--- a/src/components/admin/users/UserRoleManagement.tsx
+++ b/src/components/admin/users/UserRoleManagement.tsx
@@ -78,20 +78,21 @@ export const UserRoleManagement: React.FC<UserRoleManagementProps> = ({
 
     setIsUpdating(true);
     try {
-      const result = await assignRoleToUser(user.id, selectedRole);
-      
-      if (result.success) {
+      const { success, error } = await assignRoleToUser(user.id, selectedRole);
+
+      if (success) {
         toast.success(`User role updated to ${selectedRole}`);
-        onRoleUpdate?.();
+        await onRoleUpdate?.();
         setIsOpen(false);
       } else {
-        const errorMessage = result.error?.message || 'Failed to update user role';
-        toast.error(errorMessage);
+        toast.error(error?.message || 'Failed to update user role');
       }
-    } catch (error) {
-      console.error('Error updating role:', error);
-      const errorMessage = error instanceof Error ? error.message : 'An error occurred while updating the role';
-      toast.error(errorMessage);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : 'An error occurred while updating the role';
+      toast.error(message);
     } finally {
       setIsUpdating(false);
     }


### PR DESCRIPTION
## Summary
- tidy user role change handler and await optional callback
- simplify error handling in role update dialog

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other existing errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f7c7c025c83218e2ddbd27e34f4b0